### PR TITLE
Use canonical path for template directory

### DIFF
--- a/src/main/java/com/mapr/synth/Synth.java
+++ b/src/main/java/com/mapr/synth/Synth.java
@@ -107,7 +107,7 @@ public class Synth {
             final Configuration cfg = new Configuration(Configuration.VERSION_2_3_21);
             cfg.setDefaultEncoding("UTF-8");
             cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
-            cfg.setDirectoryForTemplateLoading(opts.template.getAbsoluteFile().getParentFile());
+            cfg.setDirectoryForTemplateLoading(opts.template.getCanonicalFile().getParentFile());
 
             template = cfg.getTemplate(opts.template.getName());
         }


### PR DESCRIPTION
FreeMarker checks that the template file's canonical path begins with the template directory. This change lets us use templates that are symlinked from elsewhere.